### PR TITLE
SFX-248: Remove module property from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "description": "Shared event names and interfaces used in the SF-X project",
   "main": "dist/index.js",
-  "module": "src/index.ts",
   "types": "dist/index.d.ts",
   "esnext": "esnext/index.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "esnext": "esnext/index.ts",
+  "files": [
+    "dist/",
+    "esnext/",
+    "src/"
+  ],
   "scripts": {
     "prepare": "npm run build",
     "build": "tsc && tsc -p tsconfig.esnext.json",


### PR DESCRIPTION
This conflicts with Webpack when the package is inside node_modules.

Also ensure that build files are included when publishing

The "dist" and "esnext" directories are excluded by .gitignore and would
therefore be excluded when publishing. Adding them to the "files" field
in package.json ensures that they are included.