### PR TITLE
SFX-248: Correct name of AutocompleteActiveTermPayload

### DIFF
--- a/src/sayt/autocomplete-list.ts
+++ b/src/sayt/autocomplete-list.ts
@@ -3,4 +3,4 @@ import { WithQuery, WithGroup } from '../includes';
 /** The name of the event fired to change the active query term. */
 export const AUTOCOMPLETE_ACTIVE_TERM = 'sfx::autocomplete_active_term';
 /** The type of the [[AUTOCOMPLETE_ACTIVE_TERM]] event payload. */
-export interface AutocompleteActiveTerm extends WithQuery, WithGroup {}
+export interface AutocompleteActiveTermPayload extends WithQuery, WithGroup {}


### PR DESCRIPTION
It was missing the Payload suffix.