### PR TITLE
SFX-158: Add cache-related events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `AUTOCOMPLETE_ERROR`
     - `AUTOCOMPLETE_REQUEST`
     - `AUTOCOMPLETE_RESPONSE`
+    - `CACHE_ERROR`
+    - `CACHE_REQUEST`
+    - `CACHE_RESPONSE`
     - `SAYT_HIDE`
     - `SAYT_SHOW`
     - `SEARCHBOX_CLEARED`
@@ -26,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `AutocompleteResponsePayload`
     - `AutocompleteResultGroup`
     - `AutocompleteSearchTermItem`
+    - `CacheErrorPayload`
+    - `CacheRequestPayload`
+    - `CacheResponsePayload`
     - `Product`
     - `ProductVariant`
     - `ProductVariants`

--- a/src/cache/cache.ts
+++ b/src/cache/cache.ts
@@ -1,0 +1,11 @@
+import { WithGroup } from '../includes/group';
+
+/** The name of the event fired when data is being requested from the cache. */
+export const CACHE_REQUEST = 'sfx::cache_request';
+/** The type of the [[CACHE_REQUEST]] event payload. */
+export interface CacheRequestPayload extends WithGroup {
+  /** The name of the cached data to return. */
+  name: string;
+  /** The name of the event under which to dispatch the cached data. */
+  returnEvent: string;
+}

--- a/src/cache/cache.ts
+++ b/src/cache/cache.ts
@@ -1,4 +1,4 @@
-import { WithGroup } from '../includes/group';
+import { ErrorPayload, WithGroup } from '../includes';
 
 /** The name of the event fired when data is being requested from the cache. */
 export const CACHE_REQUEST = 'sfx::cache_request';
@@ -19,3 +19,8 @@ export interface CacheResponsePayload extends WithGroup {
   /** The data that was cached. */
   data: string;
 }
+
+/** The name of the event fired when retrieving data from the cache failed. */
+export const CACHE_ERROR = 'sfx::cache_error';
+/** The type of the [[CACHE_ERROR]] event payload. */
+export interface CacheErrorPayload extends ErrorPayload, WithGroup {}

--- a/src/cache/cache.ts
+++ b/src/cache/cache.ts
@@ -9,3 +9,13 @@ export interface CacheRequestPayload extends WithGroup {
   /** The name of the event under which to dispatch the cached data. */
   returnEvent: string;
 }
+
+/** The name of the event fired when data is returned from the cache. */
+export const CACHE_RESPONSE = 'sfx::cache_response';
+/** The type of the [[CACHE_RESPONSE]] event payload. */
+export interface CacheResponsePayload extends WithGroup {
+  /** The name of the cached data that was returned. */
+  name: string;
+  /** The data that was cached. */
+  data: string;
+}

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,0 +1,1 @@
+export * from './cache';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './includes';
+export * from './cache';
 export * from './sayt';
 export * from './search';


### PR DESCRIPTION
New events `CACHE_REQUEST`, `CACHE_RESPONSE` and `CACHE_ERROR` have been added. The `CACHE_RESPONSE` name and `CACHE_ERROR` event are not currently expected to be used by SF-X but are added for consistency.