### PR TITLE
SFX-158 fix: Remove cache response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `AUTOCOMPLETE_RESPONSE`
     - `CACHE_ERROR`
     - `CACHE_REQUEST`
-    - `CACHE_RESPONSE`
     - `SAYT_HIDE`
     - `SAYT_SHOW`
     - `SEARCHBOX_CLEARED`

--- a/src/cache/cache.ts
+++ b/src/cache/cache.ts
@@ -10,9 +10,7 @@ export interface CacheRequestPayload extends WithGroup {
   returnEvent: string;
 }
 
-/** The name of the event fired when data is returned from the cache. */
-export const CACHE_RESPONSE = 'sfx::cache_response';
-/** The type of the [[CACHE_RESPONSE]] event payload. */
+/** The type of the cache response event payload. */
 export interface CacheResponsePayload extends WithGroup {
   /** The name of the cached data that was returned. */
   name: string;


### PR DESCRIPTION
There was a `CACHE_RESPONSE` constant added to this repository. However, the explanation of the constant indicated that it was not actually used in the Logic Layer. I have therefore removed this as a constant.

The full slice of functionality is as follows:
* The View Layer will emit a `CACHE_REQUEST` event containing the name of the event it wants dispatched for providing the cache data.
* The Logic Layer will then emit that event.
  * It will be updated to describe that it is emitting an unknown event name based on `CACHE_REQUEST` instead of referring to `CACHE_RESPONSE` (which is never used).